### PR TITLE
Use smaller Bitnami image as source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM bitnami/node:10-prod
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This Bitnami images contains only necessary sources required for running in a production enviornment, while the community's official contains also a lot of development dependencies. Image size went from 1 GB to 200 MB.