### PR TITLE
Add support for X-FORWARDED-PROTO

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,6 +1,8 @@
 const { request } =  require('http')
 
 const proxy = (req, res, next, proxyHost) => {
+  headers = req.headers;
+  headers['X-FORWARDED-PROTO'] = 'https';
 
   const proxiedRequest = request(
     {
@@ -8,7 +10,7 @@ const proxy = (req, res, next, proxyHost) => {
       port: 80,
       path: req.url,
       method: req.method,
-      headers: req.headers
+      headers: headers
     },
     response => {
       res.writeHead(response.statusCode, response.headers)


### PR DESCRIPTION
Hello,

I got a problem using Rails 6 as it is configured by default with your docker proxy.

So I propose this little fix that use what seems to be used as a standard (at least for nginx reverse proxy) and supported by rails since Rails 4 (which is pretty old) I think.

I kept it simple.